### PR TITLE
Change payload

### DIFF
--- a/theory/System/PathORAM.v
+++ b/theory/System/PathORAM.v
@@ -2517,6 +2517,4 @@ Proof.
   apply write_and_read_access_lift. auto.
 Qed.
 
-Check write_and_read_access.
-
 End PORAM.

--- a/theory/System/PathORAM.v
+++ b/theory/System/PathORAM.v
@@ -2502,10 +2502,10 @@ Lemma extract_payload (id : block_id) (v: nat) (s : state) :
 Proof.
   intros ops_on_s.
   unfold get_payload.
-  pose proof (dist_lift_peek _ _ ops_on_s) as pf.
+  apply dist_lift_peek in ops_on_s.
   destruct peek.
   destruct p.
-  destruct pf; congruence.
+  destruct ops_on_s; congruence.
 Qed.
 
 Theorem PathORAM_simulates_RAM (id : block_id) (v : nat) (s : state) :

--- a/theory/System/PathORAM.v
+++ b/theory/System/PathORAM.v
@@ -346,18 +346,6 @@ Record well_formed (s : state ) : Prop :=
 
 Definition read_access (id : block_id) : Poram (path * nat) := access id Read.
 
-Lemma dist_lift_peek {X} (P : X -> Prop) (dx : dist X) :
-  dist_lift P dx ->
-  P (peek dx).
-Proof.
-  intro.
-  destruct dx; simpl.
-  destruct dist_pmf.
-  - destruct zero_one_neq.
-  - destruct p.
-    inversion H; auto.
-Qed.
-
 Definition write_access (id : block_id) (v : nat) : Poram (path * nat) := access id (Write v).
 
 Definition write_and_read_access (id : block_id) (v : nat) : Poram (path * nat) :=

--- a/theory/Utils/Distributions.v
+++ b/theory/Utils/Distributions.v
@@ -153,3 +153,21 @@ Fixpoint mk_n_list (n: nat):list nat :=
   | O => []
   | S n' => [n'] ++ mk_n_list n'
   end.
+
+Lemma zero_one_neq : ~ (0 == 1)%Q.
+Proof.
+  intro pf.
+  inversion pf.
+Qed.
+
+(* extract a value from a distribution arbitrarily, in this case
+   taking the first elt of the underlying list *)
+Definition peek {X} (d : dist X) : X :=
+  match d with
+  | {| dist_pmf := dist; dist_law := law |} =>
+    match dist as l return ((sum_dist l == 1)%Q -> X) with
+    | [] => fun law => 
+      match zero_one_neq law with end
+    | (x,_) :: _ => fun _ => x
+       end law
+  end.

--- a/theory/Utils/Distributions.v
+++ b/theory/Utils/Distributions.v
@@ -180,6 +180,18 @@ Proof.
   eapply (Forall P (List.map fst dist_pmf0)).
 Defined.
 
+Lemma dist_lift_peek {X} (P : X -> Prop) (dx : dist X) :
+  dist_lift P dx ->
+  P (peek dx).
+Proof.
+  intro Hdx.
+  destruct dx as [dist law]; simpl.
+  destruct dist as [|p dist].
+  - destruct zero_one_neq.
+  - destruct p.
+    inversion Hdx; auto.
+Qed.
+
 Lemma dist_lift_ret : forall (X : Type) (x : X) (P : X -> Prop), P x -> dist_lift P (mreturn x).
 Proof.
   intros; simpl.


### PR DESCRIPTION
- Creates a `peek` function that extracts an `X` value from a `dist X`
- Proves `dist_lift_peek`
- Restructures proof of `extract_payload` to use `dist_lift_peek`
- Removes use of option type in statement of `PathORAM_simulates_RAM`